### PR TITLE
[WIP] Restructure Webhook docs

### DIFF
--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -180,7 +180,7 @@ paths:
                 -   http_bearer: []
 components:
     schemas:
-        event_notification_batch_created:
+        Event_NotificationBatchCreated:
             allOf:
                 -   $ref: '#/components/schemas/event'
                 -   type: object
@@ -369,7 +369,7 @@ components:
             discriminator:
                 propertyName: type
                 mapping:
-                    notification_batch.created: '#/components/schemas/event_notification_batch_created'
+                    notification_batch.created: '#/components/schemas/Event_NotificationBatchCreated'
                     ping: '#/components/schemas/event_ping'
         ping_response:
             title: Ping

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -180,81 +180,6 @@ paths:
                 -   http_bearer: []
 components:
     schemas:
-        Event_NotificationBatchCreated:
-            allOf:
-                -   $ref: '#/components/schemas/Event'
-                -   type: object
-                    properties:
-                        data:
-                            $ref: '#/components/schemas/NotificationBatch'
-        Notification.Payload_TimetableChange.Schedule.Date:
-            title: Schedule date
-            description: >-
-                Represents a date in a schedule.
-
-
-                Either `date` or `dateTime` is set.  When `dateTime` is returned, `date` is set to null, and
-                vice versa.
-
-
-                `date` is used if this is an all-day event, otherwise `dateTime` is used.
-            type: object
-            properties:
-                date:
-                    format: date
-                    description: 'A date represented as a string in ISO8601 date format. Format used: `YYYY-MM-DD`.'
-                    type: string
-                    nullable: true
-                    example: '2019-04-23'
-                dateTime:
-                    format: date-time
-                    description: >-
-                        A date-time represented as a string in ISO8601 combined date and time format
-                        (including timezone). Format used: `YYYY-MM-DDThh:mm±hh:mm`.
-                    type: string
-                    nullable: true
-                    example: '2019-04-23T08:45+02:00'
-        Notification.Payload_TimetableChange.Schedule:
-            title: Schedule
-            description: |-
-                A schedule of a timetabled event.
-
-                `start` and `end` both return either `dateTime` (for regular events) or `date` (for all-day events).
-                `end` is inclusive in case of all-day events, exclusive otherwise.
-            type: object
-            properties:
-                start:
-                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
-                end:
-                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
-                multiDay:
-                    description: True if the timetabled event spans multiple days.
-                    type: boolean
-            nullable: true
-            example:
-                start:
-                    dateTime: '2019-04-23T08:45+01:00'
-                end:
-                    dateTime: '2019-04-23T09:45+01:00'
-                multiDay: false
-        NotificationBatch:
-            title: Notification batch
-            description: A batch of notifications.
-            type: object
-            properties:
-                type:
-                    description: >-
-                        The type of notifications in this batch. All notifications in this batch have this type.
-                    type: string
-                user:
-                    description: Targeted user for the notification.
-                    type: string
-                    example: john.doe@example.org
-                notifications:
-                    description: The notifications in this batch.
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/Notification'
         Event:
             title: Event
             description: An event triggered
@@ -273,6 +198,13 @@ components:
                 mapping:
                     notification_batch.created: '#/components/schemas/Event_NotificationBatchCreated'
                     ping: '#/components/schemas/Event_Ping'
+        Event_NotificationBatchCreated:
+            allOf:
+                -   $ref: '#/components/schemas/Event'
+                -   type: object
+                    properties:
+                        data:
+                            $ref: '#/components/schemas/NotificationBatch'
         Event_Ping:
             allOf:
                 -   $ref: '#/components/schemas/Event'
@@ -285,6 +217,33 @@ components:
                                 ping:
                                     type: boolean
                                     example: true
+        LocalizedString:
+            description: String with representations in multiple locales.
+            type: object
+            properties:
+                '@type':
+                    description: >-
+                        Type of this object, which is always `"localized_string"`. Can be used as a hint while parsing.
+                    type: string
+                    example: localized_string
+                defaultValue:
+                    description: Representation for the default locale.
+                    type: string
+                localizedValues:
+                    description: >-
+                        Object containing representations for additional locales. The representation for the default
+                        locale is not included, so this map can be empty. Attribute names are
+                        [BCP47](https://tools.ietf.org/html/bcp47) language tags and their values are the actual
+                        representations.
+                    type: object
+                    additionalProperties:
+                        type: string
+            example:
+                '@type': localized_string
+                defaultValue: This is a localised message.
+                localizedValues:
+                    en-US: This is a localized message.
+                    nl: Dit is een gelokaliseerd bericht.
         Notification:
             title: Notification
             description: >-
@@ -419,33 +378,74 @@ components:
                     description: URL where the user can view their timetable.
                     type: string
                     example: 'https://mytimetable.example.org'
-        LocalizedString:
-            description: String with representations in multiple locales.
+        Notification.Payload_TimetableChange.Schedule:
+            title: Schedule
+            description: |-
+                A schedule of a timetabled event.
+
+                `start` and `end` both return either `dateTime` (for regular events) or `date` (for all-day events).
+                `end` is inclusive in case of all-day events, exclusive otherwise.
             type: object
             properties:
-                '@type':
-                    description: >-
-                        Type of this object, which is always `"localized_string"`. Can be used as a hint while parsing.
-                    type: string
-                    example: localized_string
-                defaultValue:
-                    description: Representation for the default locale.
-                    type: string
-                localizedValues:
-                    description: >-
-                        Object containing representations for additional locales. The representation for the default
-                        locale is not included, so this map can be empty. Attribute names are
-                        [BCP47](https://tools.ietf.org/html/bcp47) language tags and their values are the actual
-                        representations.
-                    type: object
-                    additionalProperties:
-                        type: string
+                start:
+                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
+                end:
+                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
+                multiDay:
+                    description: True if the timetabled event spans multiple days.
+                    type: boolean
+            nullable: true
             example:
-                '@type': localized_string
-                defaultValue: This is a localised message.
-                localizedValues:
-                    en-US: This is a localized message.
-                    nl: Dit is een gelokaliseerd bericht.
+                start:
+                    dateTime: '2019-04-23T08:45+01:00'
+                end:
+                    dateTime: '2019-04-23T09:45+01:00'
+                multiDay: false
+        Notification.Payload_TimetableChange.Schedule.Date:
+            title: Schedule date
+            description: >-
+                Represents a date in a schedule.
+
+
+                Either `date` or `dateTime` is set.  When `dateTime` is returned, `date` is set to null, and
+                vice versa.
+
+
+                `date` is used if this is an all-day event, otherwise `dateTime` is used.
+            type: object
+            properties:
+                date:
+                    format: date
+                    description: 'A date represented as a string in ISO8601 date format. Format used: `YYYY-MM-DD`.'
+                    type: string
+                    nullable: true
+                    example: '2019-04-23'
+                dateTime:
+                    format: date-time
+                    description: >-
+                        A date-time represented as a string in ISO8601 combined date and time format
+                        (including timezone). Format used: `YYYY-MM-DDThh:mm±hh:mm`.
+                    type: string
+                    nullable: true
+                    example: '2019-04-23T08:45+02:00'
+        NotificationBatch:
+            title: Notification batch
+            description: A batch of notifications.
+            type: object
+            properties:
+                type:
+                    description: >-
+                        The type of notifications in this batch. All notifications in this batch have this type.
+                    type: string
+                user:
+                    description: Targeted user for the notification.
+                    type: string
+                    example: john.doe@example.org
+                notifications:
+                    description: The notifications in this batch.
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Notification'
     securitySchemes:
         http_basic_auth:
             type: http

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -187,7 +187,7 @@ components:
                     properties:
                         data:
                             $ref: '#/components/schemas/NotificationBatch'
-        schedule_date:
+        Notification.Payload_TimetableChange.Schedule.Date:
             title: Schedule date
             description: >-
                 Represents a date in a schedule.
@@ -239,9 +239,9 @@ components:
             type: object
             properties:
                 start:
-                    $ref: '#/components/schemas/schedule_date'
+                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
                 end:
-                    $ref: '#/components/schemas/schedule_date'
+                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
                 multiDay:
                     description: True if the timetabled event spans multiple days.
                     type: boolean

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -345,7 +345,7 @@ components:
                     description: The notifications in this batch.
                     type: array
                     items:
-                        $ref: '#/components/schemas/notification'
+                        $ref: '#/components/schemas/Notification'
         Event:
             title: Event
             description: An event triggered
@@ -379,7 +379,7 @@ components:
                 ping:
                     type: boolean
                     example: true
-        notification:
+        Notification:
             title: Notification
             description: >-
                 Represents a notification that can be sent to a user.
@@ -437,7 +437,7 @@ components:
                     timetable_change: '#/components/schemas/notification_timetable_change'
         notification_timetable_change:
             allOf:
-                -   $ref: '#/components/schemas/notification'
+                -   $ref: '#/components/schemas/Notification'
                 -   type: object
                     properties:
                         payload:

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -186,7 +186,7 @@ components:
                 -   type: object
                     properties:
                         data:
-                            $ref: '#/components/schemas/notification_batch'
+                            $ref: '#/components/schemas/NotificationBatch'
         schedule_date:
             title: Schedule date
             description: >-
@@ -328,7 +328,7 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/timetable_change_event_attribute'
-        notification_batch:
+        NotificationBatch:
             title: Notification batch
             description: A batch of notifications.
             type: object

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -84,6 +84,32 @@ info:
           - Authentication using Bearer tokens
 
         <security-definitions />
+
+        # Localization
+
+        Echo is currently unaware of the user's preferred locale. So when one wants to localize messages
+        presented to the user, let's say render notifications in an app, this localization needs to happen in
+        the app.
+
+        For this reason, API responses can include human-readable strings in multiple locales.
+
+        These are organised in the following `LocalizedString` object structure as documented below.
+
+        The API user can then select the representation in the desired locale.
+
+        It should check whether a locale-specific representation is available and fall back to the default
+        representation if unavailable.
+
+
+        This also means this datatype can be used in notification payloads when posting notifications to Echo.
+        Currently, when Echo renders notifications (for example, when sending email notifications) it uses
+        the representation for the default locale.
+
+        ### LocalizedString
+
+        String with representations in multiple locales.
+
+        <SchemaDefinition schemaRef="#/components/schemas/LocalizedString" />
     contact:
         name: API Support
         url: 'https://mytimetable.net'

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -302,65 +302,116 @@ components:
                             type: string
                             example: 2019!9347347
                         created:
-                            description: True if the timetabled event is a newly created one.
+                            description: >-
+                                `true` if the event has been added to the timetable. Mutually exclusive with
+                                `updated` and `removed`.
+
+
+                                `newSchedule` contains the schedule of the newly created event. `attributes`
+                                contains all attributes. Since there are no old attribute values, they are
+                                all `null`.
                             type: boolean
                             example: false
                         updated:
-                            description: True if an existing timetabled event has been updated.
+                            description: >-
+                                `true` if the event already was and remains in the timetable. Mutually
+                                exclusive with `updated` and `removed`.
+
+
+                                `oldSchedule` contains the schedule of the event before the update,
+                                `newSchedule` contains the schedule of the event after the update.
+                                `attributes` only contains changed attributes. Old or new values can be
+                                `null` when an attribute was added or removed.
                             type: boolean
                             example: false
                         removed:
-                            description: True if an timetabled event has been unscheduled.
+                            description: >-
+                                `true` if the event has been removed from the timetable. Mutually exclusive
+                                with `updated` and `removed`.
+
+
+                                `oldSchedule` contains the schedule of the event before removal. `attributes`
+                                 is empty. In a future implementation, `attributes` might include the old
+                                 values.
                             type: boolean
                             example: false
                         scheduleUpdated:
-                            description: True if the event has been created, rescheduled or removed.
+                            description: >-
+                                `true` if the event has been `created`, `removed` or rescheduled (the start
+                                and/or end of the event has changed).
+
+
+                                `oldSchedule` contains the schedule of the event before removal or
+                                rescheduling. `newSchedule` contains the schedule of the event after creation
+                                 or rescheduling.
                             type: boolean
                             example: false
                         name:
-                            $ref: '#/components/schemas/LocalizedString'
+                            allOf:
+                                -   description: >-
+                                        Human-readable name of the event. See
+                                        [LocalizedString](#section/Localization).
+                                -   $ref: '#/components/schemas/LocalizedString'
                         oldSchedule:
-                            $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
+                            allOf:
+                                -   description: >-
+                                        The schedule of the event before it was removed or rescheduled.
+                                    nullable: true
+                                -   $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
                         newSchedule:
-                            $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
+                            allOf:
+                                -   description: >-
+                                        The schedule of the event after it has been created or rescheduled.
+                                    nullable: true
+                                -   $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
                         attributes:
                             description: An array of changed attributes for this event.
                             type: array
                             items:
-                                description: |-
-                                    Represents an attribute of an event that has been changed.
-
-                                    `label` is a localized string of the attribute label.
-
-                                    `old` is a localized string of the old attribute value.
-
-                                    `new` is a localized string of the new attribute value.
+                                description: >-
+                                    Represents a change in an attribute of an event. For example, this could
+                                    contain a location attribute when the event has been moved to another
+                                    location.
                                 type: object
                                 properties:
                                     name:
-                                        description: Unique name of the attribute.
+                                        description: Machine-readable name of the attribute.
                                         type: string
                                         example: location
                                     label:
-                                        $ref: '#/components/schemas/LocalizedString'
+                                        allOf:
+                                            -   description: >-
+                                                    Human-readable name of the attribute. See
+                                                    [LocalizedString](#section/Localization).
+                                            -   $ref: '#/components/schemas/LocalizedString'
                                     new:
                                         allOf:
+                                            -   description: >-
+                                                    The value of the attribute after the change. See
+                                                    [LocalizedString](#section/Localization).
+                                                nullable: true
                                             -   $ref: '#/components/schemas/LocalizedString'
-                                            -   nullable: true
                                     old:
                                         allOf:
+                                            -   description: >-
+                                                    The value of the attribute before the change. See
+                                                    [LocalizedString](#section/Localization).
+                                                nullable: true
                                             -   $ref: '#/components/schemas/LocalizedString'
-                                            -   nullable: true
                 timetable:
                     description: Timetable the changed event belongs to.
                     type: object
                     properties:
                         id:
-                            description: The ID of the timetable that has been changed.
+                            description: ID of the timetable the changed event belongs to.
                             type: string
                             example: 2019!student!23452
                         name:
-                            $ref: '#/components/schemas/LocalizedString'
+                            allOf:
+                                -   description: >-
+                                        Human-readable name of the timetable the changed event belongs to. See
+                                        [LocalizedString](#section/Localization).
+                                -   $ref: '#/components/schemas/LocalizedString'
                 viewTimetableUrl:
                     format: url
                     description: URL where the user can view their timetable.
@@ -424,13 +475,18 @@ components:
             type: object
             properties:
                 start:
-                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
+                    allOf:
+                        -   description: Start of the event.
+                            nullable: true
+                        -   $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
                 end:
-                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
+                    allOf:
+                        -   description: End of the event.
+                            nullable: true
+                        -   $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule.Date'
                 multiDay:
                     description: True if the timetabled event spans multiple days.
                     type: boolean
-            nullable: true
             example:
                 start:
                     dateTime: '2019-04-23T08:45+01:00'

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -436,7 +436,7 @@ components:
                     type: object
                     example:
                         ...: See 'Notification types' for example payloads per notification type.
-        notification_timetable_change:
+        Notification.Payload_TimetableChange:
             title: timetable_change
             type: object
             properties:
@@ -665,5 +665,5 @@ tags:
 
             ### payload
 
-            <SchemaDefinition schemaRef="#/components/schemas/notification_timetable_change" />
+            <SchemaDefinition schemaRef="#/components/schemas/Notification.Payload_TimetableChange" />
         x-displayName: Well-known Notification Types

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -23,10 +23,10 @@ info:
         ### Receiving data
 
 
-        Echo will make a HTTP `POST` request to the configured webhook URL. All requests will be sent with
-        content type `application/json` and will contain an `event` message with a `data` property that is
-        specific to the type of event. Please refer to the [Webhook call](#operation/WebhookCall) POST
-        endpoint for details on the exact contents of the request body and headers.
+        Echo makes a HTTP `POST` request to the configured webhook URL. All requests are sent with content
+        type `application/json` and contain an `event` message with a `data` property that is specific to the
+        type of event. Please refer to the [Webhook call](#operation/WebhookCall) POST endpoint for details
+        on the exact contents of the request body and headers.
 
 
         *At least once* delivery is used. This means that events might be delivered multiple times, for
@@ -45,13 +45,13 @@ info:
         should return an empty body with your response.
 
 
-        Any other HTTP status codes indicates that you did not receive the webhook and will be considered an
-        error response. This includes HTTP `3xx` redirection codes, these will not be followed by Echo.
-        Endpoints must never send a response larger that `32KB`.
+        Any other HTTP status codes indicates that you did not receive the webhook and are considered an
+        error response. This includes HTTP `3xx` redirection codes, these are not followed by Echo. Endpoints
+        must never send a response larger that `32KB`.
 
 
         Receiving endpoints must respond to Echo within 10 seconds. If no response is received within 10
-        seconds, this will be considered an error response.
+        seconds, this is considered an error response.
 
 
         It is best practice to acknowledge webhook requests immediately, and defer processing of the request
@@ -61,14 +61,14 @@ info:
         ### Error handling
 
 
-        If a request to the receiving endpoints fails, Echo will start a retry process. As a result of this,
+        If a request to the receiving endpoints fails, Echo starts a retry process. As a result of this,
         events might be delivered multiple times (for example when an endpoint _did_ receive a message, but
         _did not_ respond within 10 seconds). Endpoints can use the `X-Echo-Delivery-Id` HTTP header to
         deduplicate events.
 
 
         Echo might drop events if a certain delivery queue size threshold is exceeded due to retries. The
-        oldest events will be dropped first. When endpoints are down for an extended period of time, they
+        oldest events is dropped first. When endpoints are down for an extended period of time, they
         might be automatically disabled.
 
 
@@ -128,8 +128,9 @@ paths:
             tags:
                 - Calls
             summary: Webhook call
-            description: |-
+            description: >-
                 Use webhooks to be notified about events that happen in Echo.
+
 
                 Echo can send webhook events that notify your application any time an event happens.
             operationId: WebhookCall
@@ -181,13 +182,11 @@ paths:
 components:
     schemas:
         Event:
-            title: Event
-            description: An event triggered
             type: object
             properties:
                 id:
                     format: uuid
-                    description: Unique identifier for the event.
+                    description: Unique identifier of the event.
                     type: string
                     example: f9d421d5-63e3-4724-8a21-d7d81d81417a
                 type:
@@ -211,10 +210,11 @@ components:
                 -   type: object
                     properties:
                         data:
-                            description: Ping response. Always returns `true`.
+                            description: Ping response data object.
                             type: object
                             properties:
                                 ping:
+                                    description: Always returns `true`.
                                     type: boolean
                                     example: true
         LocalizedString:
@@ -223,7 +223,8 @@ components:
             properties:
                 '@type':
                     description: >-
-                        Type of this object, which is always `"localized_string"`. Can be used as a hint while parsing.
+                        Type of this object, which is always `localized_string`. Can be used as a hint while
+                        parsing.
                     type: string
                     example: localized_string
                 defaultValue:
@@ -231,10 +232,10 @@ components:
                     type: string
                 localizedValues:
                     description: >-
-                        Object containing representations for additional locales. The representation for the default
-                        locale is not included, so this map can be empty. Attribute names are
-                        [BCP47](https://tools.ietf.org/html/bcp47) language tags and their values are the actual
-                        representations.
+                        Object containing representations for additional locales. The representation for the
+                        default locale is not included, so this map can be empty. Attribute names are
+                        [BCP47](https://tools.ietf.org/html/bcp47) language tags and their values are the
+                        actual representations.
                     type: object
                     additionalProperties:
                         type: string
@@ -245,26 +246,12 @@ components:
                     en-US: This is a localized message.
                     nl: Dit is een gelokaliseerd bericht.
         Notification:
-            title: Notification
             description: >-
-                Represents a notification that can be sent to a user.
+                Represents a notification sent to a user.
 
 
-                A notification is targeted to one user. The priority of a notification can be one of the
-                following:
-
-
-                - `LOW`
-
-                - `DEFAULT`
-
-                - `HIGH`
-
-
-                A notification contains a payload that depends on the type of notification sent. The
-                notification type can be one of the following:
-
-                - `timetable_change`
+                A notification contains a payload that depends on the type of notification sent. See
+                [Well-known Notification Types](#tag/WellKnownNotificationTypes).
             type: object
             properties:
                 id:
@@ -285,17 +272,18 @@ components:
                     description: >-
                         Time at which the notification was created.
 
-                        A date-time represented as a string in ISO8601 combined date and time format
-                        (including timezone). Format used: `YYYY-MM-DDThh:mm:ss.sss±hh:mm`.
+
+                        ISO8601 formatted date-time string including timezone offset
+                        (`YYYY-MM-DDThh:mm±hh:mm`).
                     type: string
                     example: '2019-04-23T08:45:23.000+01:00'
                 type:
                     description: Type of the notification.
                     type: string
                 user:
-                    description: Targeted user for the notification.
+                    description: Target user for the notification.
                     type: string
-                    example: john.doe@example.org
+                    example: john.doe
                 payload:
                     description: The payload of the notification.
                     type: object
@@ -374,7 +362,7 @@ components:
                         name:
                             $ref: '#/components/schemas/LocalizedString'
                 viewTimetableUrl:
-                    format: uri
+                    format: url
                     description: URL where the user can view their timetable.
                     type: string
                     example: 'https://mytimetable.example.org'
@@ -433,12 +421,6 @@ components:
                             nl: John Doe (23452)
                 viewTimetableUrl: 'https://mytimetable.example.org'
         Notification.Payload_TimetableChange.Schedule:
-            title: Schedule
-            description: |-
-                A schedule of a timetabled event.
-
-                `start` and `end` both return either `dateTime` (for regular events) or `date` (for all-day events).
-                `end` is inclusive in case of all-day events, exclusive otherwise.
             type: object
             properties:
                 start:
@@ -456,45 +438,39 @@ components:
                     dateTime: '2019-04-23T09:45+01:00'
                 multiDay: false
         Notification.Payload_TimetableChange.Schedule.Date:
-            title: Schedule date
-            description: >-
-                Represents a date in a schedule.
-
-
-                Either `date` or `dateTime` is set.  When `dateTime` is returned, `date` is set to null, and
-                vice versa.
-
-
-                `date` is used if this is an all-day event, otherwise `dateTime` is used.
             type: object
             properties:
                 date:
                     format: date
-                    description: 'A date represented as a string in ISO8601 date format. Format used: `YYYY-MM-DD`.'
+                    description: >-
+                        ISO8601 formatted date string (`YYYY-MM-DD`). Null when the event is *not* an all-day
+                        event.
                     type: string
                     nullable: true
                     example: '2019-04-23'
                 dateTime:
                     format: date-time
                     description: >-
-                        A date-time represented as a string in ISO8601 combined date and time format
-                        (including timezone). Format used: `YYYY-MM-DDThh:mm±hh:mm`.
+                        ISO8601 formatted date-time string including timezone offset
+                        (`YYYY-MM-DDThh:mm±hh:mm`). Null when the event is an all-day event.
                     type: string
                     nullable: true
                     example: '2019-04-23T08:45+02:00'
         NotificationBatch:
-            title: Notification batch
             description: A batch of notifications.
             type: object
             properties:
                 type:
                     description: >-
-                        The type of notifications in this batch. All notifications in this batch have this type.
+                        The type of the notifications in this batch. All notifications in a batch have the
+                        same type.
                     type: string
                 user:
-                    description: Targeted user for the notification.
+                    description: >-
+                        Target user of the notifications in this batch. All notifications in a batch have the
+                        same target user.
                     type: string
-                    example: john.doe@example.org
+                    example: john.doe
                 notifications:
                     description: The notifications in this batch.
                     type: array
@@ -503,15 +479,17 @@ components:
     securitySchemes:
         http_basic_auth:
             type: http
-            description: |-
+            description: >-
                 Basic HTTP Authentication.
+
 
                 As per [RFC 7617](https://tools.ietf.org/html/rfc7617).
             scheme: basic
         http_bearer:
             type: http
-            description: |-
+            description: >-
                 Authentication using Bearer tokens.
+
 
                 As per [RFC 6750](https://tools.ietf.org/html/rfc6750).
             scheme: bearer

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -202,7 +202,7 @@ components:
                     type: string
                     example: 2019!student!23452
                 name:
-                    $ref: '#/components/schemas/localized_string'
+                    $ref: '#/components/schemas/LocalizedString'
         schedule:
             title: Schedule
             description: |-
@@ -292,7 +292,7 @@ components:
                     type: boolean
                     example: false
                 name:
-                    $ref: '#/components/schemas/localized_string'
+                    $ref: '#/components/schemas/LocalizedString'
                 oldSchedule:
                     $ref: '#/components/schemas/schedule'
                 newSchedule:
@@ -432,7 +432,7 @@ components:
                                     description: URL where the user can view their timetable.
                                     type: string
                                     example: 'https://mytimetable.example.org'
-        localized_string:
+        LocalizedString:
             description: String with representations in multiple locales.
             type: object
             properties:
@@ -476,14 +476,14 @@ components:
                     type: string
                     example: location
                 label:
-                    $ref: '#/components/schemas/localized_string'
+                    $ref: '#/components/schemas/LocalizedString'
                 new:
                     allOf:
-                        -   $ref: '#/components/schemas/localized_string'
+                        -   $ref: '#/components/schemas/LocalizedString'
                         -   nullable: true
                 old:
                     allOf:
-                        -   $ref: '#/components/schemas/localized_string'
+                        -   $ref: '#/components/schemas/LocalizedString'
                         -   nullable: true
     securitySchemes:
         http_basic_auth:

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -162,20 +162,20 @@ paths:
             responses:
                 '200':
                     description: >-
-                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it received
-                        the request.
+                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it has
+                        received the request.
                 '201':
                     description: >-
-                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it received
-                        the request.
+                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it has
+                        received the request.
                 '202':
                     description: >-
-                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it received
-                        the request.
+                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it has
+                        received the request.
                 '204':
                     description: >-
-                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it received
-                        the request.
+                        Receiving endpoints must return a `2xx` HTTP response code to acknowledge it has
+                        received the request.
             security:
                 -   http_basic_auth: []
                 -   http_bearer: []
@@ -495,25 +495,27 @@ components:
             scheme: bearer
 tags:
     -   name: Events
-        description: |-
-            The following event types are supported:
+        description: >-
+            Events are used to communicate when something interesting happens in Echo. For example, when a
+            batch of notifications is created, an `Event` with the type `notification_batch.created` is
+            created.
 
-            - `notification_batch.created`
-            - `ping`
+            ### Event types
 
-            ### Example request bodies
+            These are the event types that currently exist:
 
-            #### ping
 
-            ````json
-            {
-                "id": "f9d421d5-63e3-4724-8a21-d7d81d81417a",
-                "type": "ping",
-                "data": {
-                    "ping": true
-                }
-            }
-            ````
+            | type                         | description                                                 |
+
+            |------------------------------|-------------------------------------------------------------|
+
+            | `notification_batch.created` | Event indicating one or more changes to a user's timetable. |
+
+            | `ping`                       | _Currently unused._                                         |
+
+
+            We may add more event types at any time, so in developing and maintaining your code, you should
+            not assume that only these types exist.
     -   name: WellKnownNotificationTypes
         description: >-
             Notification types are dynamic, so it would be impossible to list them here.

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -431,33 +431,24 @@ components:
                     description: Targeted user for the notification.
                     type: string
                     example: john.doe@example.org
-            discriminator:
-                propertyName: type
-                mapping:
-                    timetable_change: '#/components/schemas/notification_timetable_change'
+                payload:
+                    description: The payload of the notification.
+                    type: object
+                    example:
+                        ...: See 'Notification types' for example payloads per notification type.
         notification_timetable_change:
-            allOf:
-                -   $ref: '#/components/schemas/Notification'
-                -   type: object
-                    properties:
-                        payload:
-                            description: >-
-                                The payload of the notification.
-
-
-                                The payload of the `timetable_change` type describes a change in a user's
-                                timetable.
-                            type: object
-                            properties:
-                                event:
-                                    $ref: '#/components/schemas/timetable_change_event'
-                                timetable:
-                                    $ref: '#/components/schemas/timetable_change_source_timetable'
-                                viewTimetableUrl:
-                                    format: uri
-                                    description: URL where the user can view their timetable.
-                                    type: string
-                                    example: 'https://mytimetable.example.org'
+            title: timetable_change
+            type: object
+            properties:
+                event:
+                    $ref: '#/components/schemas/timetable_change_event'
+                timetable:
+                    $ref: '#/components/schemas/timetable_change_source_timetable'
+                viewTimetableUrl:
+                    format: uri
+                    description: URL where the user can view their timetable.
+                    type: string
+                    example: 'https://mytimetable.example.org'
         LocalizedString:
             description: String with representations in multiple locales.
             type: object
@@ -649,3 +640,30 @@ tags:
                 }
             }
             ````
+    -   name: WellKnownNotificationTypes
+        description: >-
+            Notification types are dynamic, so it would be impossible to list them here.
+
+            The contract is that sender and receiver should agree on the schema of the payload.
+
+            To facilitate this, we have defined some well-known notification types.
+
+
+            ## timetable_change
+
+
+            This type of notification indicates a change within the user's timetable.
+
+
+            One notification is sent per changed timetable event in a specific timetable, so when
+            multiple events change, multiple notifications are sent.
+
+            Also, when an event belongs to multiple timetables, multiple notifications are sent.
+
+            These notifications may or may not be grouped together in a batch.
+
+
+            ### payload
+
+            <SchemaDefinition schemaRef="#/components/schemas/notification_timetable_change" />
+        x-displayName: Well-known Notification Types

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -433,31 +433,23 @@ components:
                                     type: string
                                     example: 'https://mytimetable.example.org'
         localized_string:
-            title: Localized string
-            description: >-
-                Represents a String in multiple locales.
-
-
-                This object always contains a representation in the default locale, using the `defaultValue`
-                property. Other locales might be included as well in the `localizedValues` map (which does not
-                include the default locale). Locale keys are represented as
-                [BCP47](https://tools.ietf.org/html/bcp47) language tags.
+            description: String with representations in multiple locales.
             type: object
             properties:
                 '@type':
                     description: >-
-                        The type of this object. This property can be used as a hint while parsing. Value is always
-                        'localized_string'.
+                        Type of this object, which is always `"localized_string"`. Can be used as a hint while parsing.
                     type: string
                     example: localized_string
                 defaultValue:
-                    description: String represented in the default locale.
+                    description: Representation for the default locale.
                     type: string
                 localizedValues:
                     description: >-
-                        Map containing additional localized values. The default locale is not included, so
-                        this map can be empty. Locale keys are represented as
-                        [BCP47](https://tools.ietf.org/html/bcp47) language tags.
+                        Object containing representations for additional locales. The representation for the default
+                        locale is not included, so this map can be empty. Attribute names are
+                        [BCP47](https://tools.ietf.org/html/bcp47) language tags and their values are the actual
+                        representations.
                     type: object
                     additionalProperties:
                         type: string

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -229,7 +229,7 @@ components:
                     example: 2019!student!23452
                 name:
                     $ref: '#/components/schemas/LocalizedString'
-        schedule:
+        Notification.Payload_TimetableChange.Schedule:
             title: Schedule
             description: |-
                 A schedule of a timetabled event.
@@ -320,9 +320,9 @@ components:
                 name:
                     $ref: '#/components/schemas/LocalizedString'
                 oldSchedule:
-                    $ref: '#/components/schemas/schedule'
+                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
                 newSchedule:
-                    $ref: '#/components/schemas/schedule'
+                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
                 attributes:
                     description: An array of changed attributes for this event.
                     type: array

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -378,6 +378,60 @@ components:
                     description: URL where the user can view their timetable.
                     type: string
                     example: 'https://mytimetable.example.org'
+            example:
+                event:
+                    id: 2019!9347347
+                    created: false
+                    updated: true
+                    removed: false
+                    scheduleUpdated: true
+                    name:
+                        '@type': localized_string
+                        defaultValue: M-1423 - Linear algebra 101
+                        localizedValues:
+                            en-US: M-1423 - Linear algebra 101
+                            nl: M-1423 - Lineaire algebra 101
+                    oldSchedule:
+                        start:
+                            dateTime: '2019-04-23T08:45+01:00'
+                        end:
+                            dateTime: '2019-04-23T09:45+01:00'
+                        multiDay: false
+                    newSchedule:
+                        start:
+                            date: '2019-04-23'
+                        end:
+                            date: '2019-04-25'
+                        multiDay: true
+                    attributes:
+                        -   name: location
+                            label:
+                                '@type': localized_string
+                                defaultValue: Room(s)
+                                localizedValues:
+                                    en-US: Room(s)
+                                    nl: Ruimte(s)
+                            new:
+                                '@type': localized_string
+                                defaultValue: C1.241
+                                localizedValues:
+                                    en-US: C1.241
+                                    nl: C1.241
+                            old:
+                                '@type': localized_string
+                                defaultValue: C2.021
+                                localizedValues:
+                                    en-US: C2.021
+                                    nl: C2.021
+                timetable:
+                    id: 2019!student!23452
+                    name:
+                        '@type': localized_string
+                        defaultValue: John Doe (23452)
+                        localizedValues:
+                            en-US: John Doe (23452)
+                            nl: John Doe (23452)
+                viewTimetableUrl: 'https://mytimetable.example.org'
         Notification.Payload_TimetableChange.Schedule:
             title: Schedule
             description: |-
@@ -470,108 +524,6 @@ tags:
             - `ping`
 
             ### Example request bodies
-
-            #### notification_batch.created
-
-            ````json
-            {
-                "id": "f9d421d5-63e3-4724-8a21-d7d81d81417a",
-                "type": "notification_batch.created",
-                "data": {
-                    "type": "timetable_change",
-                    "user": "john.doe@example.org",
-                    "notifications": [
-                        {
-                            "id": "ef67d9ac-f97c-4a76-b914-8104aa537c0e",
-                            "priority": "HIGH",
-                            "timestamp": "2019-04-23T08:45:23.000+01:00",
-                            "type": "timetable_change",
-                            "user": "john.doe@example.org",
-                            "payload": {
-                                "event": {
-                                    "id": "2019!9347347",
-                                    "created": false,
-                                    "updated": true,
-                                    "removed": false,
-                                    "scheduleUpdated": true,
-                                    "name": {
-                                        "@type": "localized_string",
-                                        "defaultValue": "M-1423 - Linear algebra 101",
-                                        "localizedValues": {
-                                          "en-US": "M-1423 - Linear algebra 101",
-                                          "nl": "M-1423 - Lineaire algebra 101."
-                                        }
-                                    },
-                                    "oldSchedule": {
-                                        "start": {
-                                            "dateTime": "2019-04-23T08:45+01:00",
-                                            "date": null
-                                        },
-                                        "end": {
-                                            "dateTime": "2019-04-23T09:45+01:00",
-                                            "date": null
-                                        },
-                                        "multiDay": false
-                                    },
-                                    "newSchedule": {
-                                        "start": {
-                                            "dateTime": null,
-                                            "date": "2019-04-23"
-                                        },
-                                        "end": {
-                                            "dateTime": null,
-                                            "date": "2019-04-25"
-                                        },
-                                        "multiDay": true
-                                    },
-                                    "attributes": [
-                                        {
-                                            "name": "location",
-                                            "label": {
-                                                "@type": "localized_string",
-                                                "defaultValue": "Room(s)",
-                                                "localizedValues": {
-                                                  "en-US": "Room(s)",
-                                                  "nl": "Ruimte(s)"
-                                                }
-                                            },
-                                            "new": {
-                                                "@type": "localized_string",
-                                                "defaultValue": "C1.241",
-                                                "localizedValues": {
-                                                  "en-US": "C1.241",
-                                                  "nl": "C1.241"
-                                                }
-                                            },
-                                            "old": {
-                                                "@type": "localized_string",
-                                                "defaultValue": "C2.021",
-                                                "localizedValues": {
-                                                  "en-US": "C2.021",
-                                                  "nl": "C2.021"
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                "timetable": {
-                                    "id": "2019!student!23452",
-                                    "name": {
-                                        "@type": "localized_string",
-                                        "defaultValue": "John Doe (23452)",
-                                        "localizedValues": {
-                                          "en-US": "John Doe (23452)",
-                                          "nl": "John Doe (23452)"
-                                        }
-                                    }
-                                },
-                                "viewTimetableUrl": "https://mytimetable.example.org"
-                            }
-                        }
-                    ]
-                }
-            }
-            ````
 
             #### ping
 

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -214,21 +214,6 @@ components:
                     type: string
                     nullable: true
                     example: '2019-04-23T08:45+02:00'
-        timetable_change_source_timetable:
-            title: Changed timetable
-            description: |-
-                A reference to the timetable that has been changed.
-
-                `name` is a localized string of the timetable name, providing a user friendly description of the
-                timetable.
-            type: object
-            properties:
-                id:
-                    description: The ID of the timetable that has been changed.
-                    type: string
-                    example: 2019!student!23452
-                name:
-                    $ref: '#/components/schemas/LocalizedString'
         Notification.Payload_TimetableChange.Schedule:
             title: Schedule
             description: |-
@@ -252,82 +237,6 @@ components:
                 end:
                     dateTime: '2019-04-23T09:45+01:00'
                 multiDay: false
-        timetable_change_event:
-            title: Timetable changed event
-            description: >-
-                A changed event in a timetable.
-
-
-                `name` is a localized string of the event name, providing a user friendly description of the event.
-
-
-                `attributes` contains all changed attributes for this event, for example the location when an
-                event has been moved to another location.
-
-
-                Only one of the `created`, `updated` and `removed` properties can be true.
-
-
-                `oldSchedule` refers to when the old activity was scheduled, `newSchedule` to when the new activity is
-                scheduled. Their behaviour is as follows:
-
-
-                - When `created` is `true`, `oldSchedule` is `null`. `newSchedule` contains the date of the
-                current scheduled event.
-
-                - When `updated` is `true`, `newSchedule` contains the date of the rescheduled event.
-                `oldSchedule` contains the date of the old event.
-
-                - When `removed` is `true`, `newSchedule` is `null`. `oldSchedule` contains the date of the
-                unscheduled event.
-
-
-                For the `attributes` property, the behaviour is as follows:
-
-
-                - When `created` is `true`, `attributes` contains all new attribute values. Since there are no
-                old values, these will all be set to `null`.
-
-                - When `updated` is `true`, `attributes` contains all changed attribute values. Attribute
-                values that have not changed will not be included. Old or new values can be null when an attribute
-                was added or removed.
-
-                - When `removed` is `true`, `attributes` does not contain any values. In a future
-                implementation, `attributes` might include the old values of the attributes.
-
-            type: object
-            properties:
-                id:
-                    description: The ID of the event that has been changed.
-                    type: string
-                    example: 2019!9347347
-                created:
-                    description: True if the timetabled event is a newly created one.
-                    type: boolean
-                    example: false
-                updated:
-                    description: True if an existing timetabled event has been updated.
-                    type: boolean
-                    example: false
-                removed:
-                    description: True if an timetabled event has been unscheduled.
-                    type: boolean
-                    example: false
-                scheduleUpdated:
-                    description: True if the event has been created, rescheduled or removed.
-                    type: boolean
-                    example: false
-                name:
-                    $ref: '#/components/schemas/LocalizedString'
-                oldSchedule:
-                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
-                newSchedule:
-                    $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
-                attributes:
-                    description: An array of changed attributes for this event.
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/timetable_change_event_attribute'
         NotificationBatch:
             title: Notification batch
             description: A batch of notifications.
@@ -370,15 +279,12 @@ components:
                 -   type: object
                     properties:
                         data:
-                            $ref: '#/components/schemas/ping_response'
-        ping_response:
-            title: Ping
-            description: Ping response. Always returns `true`.
-            type: object
-            properties:
-                ping:
-                    type: boolean
-                    example: true
+                            description: Ping response. Always returns `true`.
+                            type: object
+                            properties:
+                                ping:
+                                    type: boolean
+                                    example: true
         Notification:
             title: Notification
             description: >-
@@ -441,9 +347,73 @@ components:
             type: object
             properties:
                 event:
-                    $ref: '#/components/schemas/timetable_change_event'
+                    description: A changed event in the target user's timetable.
+                    type: object
+                    properties:
+                        id:
+                            description: The ID of the event that has been changed.
+                            type: string
+                            example: 2019!9347347
+                        created:
+                            description: True if the timetabled event is a newly created one.
+                            type: boolean
+                            example: false
+                        updated:
+                            description: True if an existing timetabled event has been updated.
+                            type: boolean
+                            example: false
+                        removed:
+                            description: True if an timetabled event has been unscheduled.
+                            type: boolean
+                            example: false
+                        scheduleUpdated:
+                            description: True if the event has been created, rescheduled or removed.
+                            type: boolean
+                            example: false
+                        name:
+                            $ref: '#/components/schemas/LocalizedString'
+                        oldSchedule:
+                            $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
+                        newSchedule:
+                            $ref: '#/components/schemas/Notification.Payload_TimetableChange.Schedule'
+                        attributes:
+                            description: An array of changed attributes for this event.
+                            type: array
+                            items:
+                                description: |-
+                                    Represents an attribute of an event that has been changed.
+
+                                    `label` is a localized string of the attribute label.
+
+                                    `old` is a localized string of the old attribute value.
+
+                                    `new` is a localized string of the new attribute value.
+                                type: object
+                                properties:
+                                    name:
+                                        description: Unique name of the attribute.
+                                        type: string
+                                        example: location
+                                    label:
+                                        $ref: '#/components/schemas/LocalizedString'
+                                    new:
+                                        allOf:
+                                            -   $ref: '#/components/schemas/LocalizedString'
+                                            -   nullable: true
+                                    old:
+                                        allOf:
+                                            -   $ref: '#/components/schemas/LocalizedString'
+                                            -   nullable: true
                 timetable:
-                    $ref: '#/components/schemas/timetable_change_source_timetable'
+                    description: Timetable the changed event belongs to.
+                    type: object
+                    properties:
+                        id:
+                            description: The ID of the timetable that has been changed.
+                            type: string
+                            example: 2019!student!23452
+                        name:
+                            $ref: '#/components/schemas/LocalizedString'
                 viewTimetableUrl:
                     format: uri
                     description: URL where the user can view their timetable.
@@ -476,32 +446,6 @@ components:
                 localizedValues:
                     en-US: This is a localized message.
                     nl: Dit is een gelokaliseerd bericht.
-        timetable_change_event_attribute:
-            title: Changed event attribute
-            description: |-
-                Represents an attribute of an event that has been changed.
-
-                `label` is a localized string of the attribute label.
-
-                `old` is a localized string of the old attribute value.
-
-                `new` is a localized string of the new attribute value.
-            type: object
-            properties:
-                name:
-                    description: Unique name of the attribute.
-                    type: string
-                    example: location
-                label:
-                    $ref: '#/components/schemas/LocalizedString'
-                new:
-                    allOf:
-                        -   $ref: '#/components/schemas/LocalizedString'
-                        -   nullable: true
-                old:
-                    allOf:
-                        -   $ref: '#/components/schemas/LocalizedString'
-                        -   nullable: true
     securitySchemes:
         http_basic_auth:
             type: http

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -156,7 +156,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/event'
+                            $ref: '#/components/schemas/Event'
                 required: true
             responses:
                 '200':
@@ -182,7 +182,7 @@ components:
     schemas:
         Event_NotificationBatchCreated:
             allOf:
-                -   $ref: '#/components/schemas/event'
+                -   $ref: '#/components/schemas/Event'
                 -   type: object
                     properties:
                         data:
@@ -348,12 +348,12 @@ components:
                         $ref: '#/components/schemas/notification'
         event_ping:
             allOf:
-                -   $ref: '#/components/schemas/event'
+                -   $ref: '#/components/schemas/Event'
                 -   type: object
                     properties:
                         data:
                             $ref: '#/components/schemas/ping_response'
-        event:
+        Event:
             title: Event
             description: An event triggered
             type: object

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -169,7 +169,7 @@ info:
         name: API Support
         url: 'https://mytimetable.net'
         email: support@eveoh.nl
-    version: 1.0.2
+    version: 1.0.3
 servers:
     -   url: 'https://{baseUrl}'
         description: The URL of your server listening for Webhook calls.

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -346,13 +346,6 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/notification'
-        event_ping:
-            allOf:
-                -   $ref: '#/components/schemas/Event'
-                -   type: object
-                    properties:
-                        data:
-                            $ref: '#/components/schemas/ping_response'
         Event:
             title: Event
             description: An event triggered
@@ -370,7 +363,14 @@ components:
                 propertyName: type
                 mapping:
                     notification_batch.created: '#/components/schemas/Event_NotificationBatchCreated'
-                    ping: '#/components/schemas/event_ping'
+                    ping: '#/components/schemas/Event_Ping'
+        Event_Ping:
+            allOf:
+                -   $ref: '#/components/schemas/Event'
+                -   type: object
+                    properties:
+                        data:
+                            $ref: '#/components/schemas/ping_response'
         ping_response:
             title: Ping
             description: Ping response. Always returns `true`.

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -2,44 +2,42 @@ openapi: 3.0.2
 info:
     title: Echo Webhooks
     description: >
+        # Introduction
+
         This API specification describes the webhook functionality of the Echo API. Webhooks allow apps to
-        receive HTTP callbacks in real-time when events happen in Echo. The [Webhook
-        call](#operation/WebhookCall) POST endpoint describes the requests a receiving endpoint can expect.
+        receive HTTP callbacks in real-time when events happen in Echo.
 
 
-        ### Creating an endpoint for webhooks
+        Echo makes a HTTP `POST` request to a webhook URL. All requests are sent with content type
+        `application/json` and contain an `event` message (see [Events](#section/Events)).
 
+
+        Please refer to the [Webhook call](#operation/WebhookCall) POST endpoint
+        for details on the exact contents of the request body and headers.
+
+
+        # Endpoint requirements
 
         The receiving endpoint must:
 
 
         - be accessible via an HTTPS address with a valid SSL certificate
 
-        - be able to correctly process `event` requests
+        - be able to correctly process `event` requests (see [Webhook call](#operation/WebhookCall))
+
+        - respond to the request within 10 seconds
 
         - never send a response larger that `32KB`.
 
 
-        ### Receiving data
-
-
-        Echo makes a HTTP `POST` request to the configured webhook URL. All requests are sent with content
-        type `application/json` and contain an `event` message with a `data` property that is specific to the
-        type of event. Please refer to the [Webhook call](#operation/WebhookCall) POST endpoint for details
-        on the exact contents of the request body and headers.
-
+        ## Handling duplicate events
 
         *At least once* delivery is used. This means that events might be delivered multiple times, for
-        example as a result of [error handling](#error-handling). Endpoints can use the `X-Echo-Delivery-Id`
-        HTTP header to deduplicate events.
+        example as a result of [error handling](#section/Error-handling). Endpoints can use the
+        `X-Echo-Delivery-Id` HTTP header to deduplicate events.
 
 
-        Echo supports Basic Authentication and Bearer tokens via the `Authorization` HTTP header. It is up to
-        the receiving endpoint to validate the credentials.
-
-
-        ### Responding to a webhook
-
+        ## Responding to a callback
 
         Receiving endpoints must return a HTTP status code `2xx` to acknowledge it received the request. You
         should return an empty body with your response.
@@ -58,13 +56,12 @@ info:
         (i.e. making additional network calls, performing complex logic, et cetera).
 
 
-        ### Error handling
-
+        # Error handling
 
         If a request to the receiving endpoints fails, Echo starts a retry process. As a result of this,
         events might be delivered multiple times (for example when an endpoint _did_ receive a message, but
         _did not_ respond within 10 seconds). Endpoints can use the `X-Echo-Delivery-Id` HTTP header to
-        deduplicate events.
+        [deduplicate events](#section/Endpoint-requirements/Handling-duplicate-events).
 
 
         Echo might drop events if a certain delivery queue size threshold is exceeded due to retries. The
@@ -76,6 +73,7 @@ info:
         that are bound to a certain time (e.g. a scheduled activity from a timetable) that has already passed
         should not be forwarded to end-users.
 
+
         # Authentication
 
         Receiving endpoints can implement two types of authentication:
@@ -83,7 +81,10 @@ info:
           - Basic HTTP Authentication
           - Authentication using Bearer tokens
 
+        It is up to the receiving endpoint to validate the credentials.
+
         <security-definitions />
+
 
         # Localization
 
@@ -116,6 +117,12 @@ info:
         Events are used to communicate when something interesting happens in Echo. For example, when a batch
         of notifications is created, an `Event` with the type `notification_batch.created` is created.
 
+
+        ## The Event object
+
+        <SchemaDefinition schemaRef="#/components/schemas/Event" />
+
+
         ## Event types
 
         These are the event types that currently exist:
@@ -143,7 +150,6 @@ info:
 
 
         ## timetable_change
-
 
         This type of notification indicates a change within the user's timetable.
 
@@ -239,7 +245,9 @@ components:
                     type: string
                     example: f9d421d5-63e3-4724-8a21-d7d81d81417a
                 type:
-                    description: 'Type of the event. See [Events](#tag/Events) for a description of all types.'
+                    description: >-
+                        Type of the event. See [Events](#section/Events/Event-types) for a description of
+                        all types.
                     type: string
             discriminator:
                 propertyName: type

--- a/spec/echo-webhooks.yaml
+++ b/spec/echo-webhooks.yaml
@@ -110,6 +110,55 @@ info:
         String with representations in multiple locales.
 
         <SchemaDefinition schemaRef="#/components/schemas/LocalizedString" />
+
+        # Events
+
+        Events are used to communicate when something interesting happens in Echo. For example, when a batch
+        of notifications is created, an `Event` with the type `notification_batch.created` is created.
+
+        ## Event types
+
+        These are the event types that currently exist:
+
+
+        | type                         | description                                                 |
+
+        |------------------------------|-------------------------------------------------------------|
+
+        | `notification_batch.created` | Event indicating one or more changes to a user's timetable. |
+
+        | `ping`                       | _Currently unused._                                         |
+
+
+        We may add more event types at any time, so in developing and maintaining your code, you should not
+        assume that only these types exist.
+
+        # Well-known Notification Types
+
+        Notification types are dynamic, so it would be impossible to list them here.
+
+        The contract is that sender and receiver should agree on the schema of the payload.
+
+        To facilitate this, we have defined some well-known notification types.
+
+
+        ## timetable_change
+
+
+        This type of notification indicates a change within the user's timetable.
+
+
+        One notification is sent per changed timetable event in a specific timetable, so when multiple events
+        change, multiple notifications are sent.
+
+        Also, when an event belongs to multiple timetables, multiple notifications are sent.
+
+        These notifications may or may not be grouped together in a batch.
+
+
+        ### payload
+
+        <SchemaDefinition schemaRef="#/components/schemas/Notification.Payload_TimetableChange" />
     contact:
         name: API Support
         url: 'https://mytimetable.net'
@@ -550,52 +599,4 @@ components:
                 As per [RFC 6750](https://tools.ietf.org/html/rfc6750).
             scheme: bearer
 tags:
-    -   name: Events
-        description: >-
-            Events are used to communicate when something interesting happens in Echo. For example, when a
-            batch of notifications is created, an `Event` with the type `notification_batch.created` is
-            created.
-
-            ### Event types
-
-            These are the event types that currently exist:
-
-
-            | type                         | description                                                 |
-
-            |------------------------------|-------------------------------------------------------------|
-
-            | `notification_batch.created` | Event indicating one or more changes to a user's timetable. |
-
-            | `ping`                       | _Currently unused._                                         |
-
-
-            We may add more event types at any time, so in developing and maintaining your code, you should
-            not assume that only these types exist.
-    -   name: WellKnownNotificationTypes
-        description: >-
-            Notification types are dynamic, so it would be impossible to list them here.
-
-            The contract is that sender and receiver should agree on the schema of the payload.
-
-            To facilitate this, we have defined some well-known notification types.
-
-
-            ## timetable_change
-
-
-            This type of notification indicates a change within the user's timetable.
-
-
-            One notification is sent per changed timetable event in a specific timetable, so when
-            multiple events change, multiple notifications are sent.
-
-            Also, when an event belongs to multiple timetables, multiple notifications are sent.
-
-            These notifications may or may not be grouped together in a batch.
-
-
-            ### payload
-
-            <SchemaDefinition schemaRef="#/components/schemas/Notification.Payload_TimetableChange" />
-        x-displayName: Well-known Notification Types
+    -   name: Calls


### PR DESCRIPTION
Ref. eveoh/echo#194

## Proposed changes

In general, the following changes have been made (mostly work by @evpaassen):

- Describe event types
- Removed payload from notification. Add separate section with well known payloads.
- Renamed schema objects to more meaningful names
- Clarified some documentation
- Restructured introductory sections
- Sorted schema objects

No API changes have been made.

## Testing

Locally built the documentation. Visual checks.

## Upgrade notes for breaking changes

- [x] `UPGRADE_NOTES.md` has been updated (when applicable).
